### PR TITLE
Added support for mixed multipart content type

### DIFF
--- a/Sources/MultipartForm/MultipartForm.swift
+++ b/Sources/MultipartForm/MultipartForm.swift
@@ -33,18 +33,18 @@ public struct MultipartForm: Hashable, Equatable {
             self.init(name: name, data: data, filename: nil, contentType: nil)
         }
     }
-
-	public enum MultipartType: String {
-		case formData = "form-data"
-		case mixed = "mixed"
-	}
+    
+    public enum MultipartType: String {
+        case formData = "form-data"
+        case mixed = "mixed"
+    }
     
     public var boundary: String
     public var parts: [Part]
-	public var multipartType: MultipartType
-
+    public var multipartType: MultipartType
+    
     public var contentType: String {
-		return "multipart/\(multipartType.rawValue); boundary=\(self.boundary)"
+        return "multipart/\(multipartType.rawValue); boundary=\(self.boundary)"
     }
     
     public var bodyData: Data {
@@ -68,10 +68,10 @@ public struct MultipartForm: Hashable, Equatable {
         return body
     }
     
-	public init(parts: [Part] = [], boundary: String = UUID().uuidString, multipartType: MultipartType = .formData) {
+    public init(parts: [Part] = [], boundary: String = UUID().uuidString, multipartType: MultipartType = .formData) {
         self.parts = parts
         self.boundary = boundary
-		self.multipartType = multipartType
+        self.multipartType = multipartType
     }
     
     public subscript(name: String) -> Part? {

--- a/Sources/MultipartForm/MultipartForm.swift
+++ b/Sources/MultipartForm/MultipartForm.swift
@@ -33,12 +33,18 @@ public struct MultipartForm: Hashable, Equatable {
             self.init(name: name, data: data, filename: nil, contentType: nil)
         }
     }
+
+	public enum MultipartType: String {
+		case formData = "form-data"
+		case mixed = "mixed"
+	}
     
     public var boundary: String
     public var parts: [Part]
-    
+	public var multipartType: MultipartType
+
     public var contentType: String {
-        return "multipart/form-data; boundary=\(self.boundary)"
+		return "multipart/\(multipartType.rawValue); boundary=\(self.boundary)"
     }
     
     public var bodyData: Data {
@@ -62,9 +68,10 @@ public struct MultipartForm: Hashable, Equatable {
         return body
     }
     
-    public init(parts: [Part] = [], boundary: String = UUID().uuidString) {
+	public init(parts: [Part] = [], boundary: String = UUID().uuidString, multipartType: MultipartType = .formData) {
         self.parts = parts
         self.boundary = boundary
+		self.multipartType = multipartType
     }
     
     public subscript(name: String) -> Part? {

--- a/Tests/MultipartFormTests/MultipartFormTests.swift
+++ b/Tests/MultipartFormTests/MultipartFormTests.swift
@@ -24,17 +24,17 @@ final class MultipartFormTests: XCTestCase {
         XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
     }
 
-	func testMultipartMixedType() {
-		let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .mixed)
+    func testMultipartMixedType() {
+        let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .mixed)
 
-		XCTAssertEqual(form.contentType, "multipart/mixed; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-	}
+        XCTAssertEqual(form.contentType, "multipart/mixed; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+    }
 
-	func testMultipartFormDataType() {
-		let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .formData)
+    func testMultipartFormDataType() {
+        let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .formData)
 
-		XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
-	}
+        XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+    }
     
     func testSubscriptGet() {
         let form = MultipartForm(parts: [

--- a/Tests/MultipartFormTests/MultipartFormTests.swift
+++ b/Tests/MultipartFormTests/MultipartFormTests.swift
@@ -23,6 +23,18 @@ final class MultipartFormTests: XCTestCase {
         
         XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
     }
+
+	func testMultipartMixedType() {
+		let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .mixed)
+
+		XCTAssertEqual(form.contentType, "multipart/mixed; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+	}
+
+	func testMultipartFormDataType() {
+		let form = MultipartForm(boundary: "9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE", multipartType: .formData)
+
+		XCTAssertEqual(form.contentType, "multipart/form-data; boundary=9BFDAA7B-7244-4DA8-916B-2311D3CD1FEE")
+	}
     
     func testSubscriptGet() {
         let form = MultipartForm(parts: [


### PR DESCRIPTION
You can now choose between `multipart/form-data` and `multipart/mixed` for the overall request Content-Type